### PR TITLE
Add map view for collections

### DIFF
--- a/app/components/collections/Thumbnails.tsx
+++ b/app/components/collections/Thumbnails.tsx
@@ -1,3 +1,5 @@
+import { faMap, faTableCells } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link } from "@remix-run/react";
 import type { ReactNode } from "react";
 import { Pagination, useHits } from "react-instantsearch";
@@ -15,6 +17,14 @@ const Thumbnails = ({ collectionType, children }: Props) => {
       <h1 className="text-3xl text-black/80 m-4 md:m-auto md:ms-2 capitalize">
         {collectionType}
       </h1>
+      <div className="flex gap-4 md:ms-2 md:my-2">
+        <button className="border border-island px-2 py-1 rounded-md shadow-md hover:shadow-lg text-island">
+          <FontAwesomeIcon icon={faTableCells} /> Grid View
+        </button>
+        <button className="border border-island px-2 py-1 rounded-md shadow-md hover:shadow-lg text-island">
+          <FontAwesomeIcon icon={faMap} /> Map View
+        </button>
+      </div>
       <div>
         <ol className="flex flex-col md:flex-none md:grid md:grid-cols-1 lg:grid-cols-3 md:pe-6">
           {items.map((item) => {


### PR DESCRIPTION
I've added placeholder buttons to the `app/components/collections/Thumbnails.tsx` component. The feature should:

- [ ] Toggle between showing items in a grid/list and on a map.
- [ ] Toggling should update the address (add to the history) with a search parameter for which view.
- [ ] When someone enters the route, the request url should be checked for the search parameter and present the items accordingly.
  - [Hint](app/components/collections/Thumbnails.tsx) - this could also be how you handle the toggle itself. Clicking a button sets the search parameter. A `useEffect` function reacts to a change in the search parameters.
  - [How to update the url](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState)

```javascript
history.pushState({}, undefined, '?view=map')
```

The item objects will have attributes for "places" and "locations." Both are arrays but will likely only include one value. The places will have GeoJSON. The locations will be an array are objects with a lat and lng key/value pairs.

- [ ] Show items on the map.
  - Use the `app/components/mapping/Map.client.tsx` component. You will probably need to wrap in a `<ClientOnly></ClientOnly>` component. You can look for examples.
 