### PR TITLE
Image Link

### DIFF
--- a/app/routes/collections.photographs.$photograph.tsx
+++ b/app/routes/collections.photographs.$photograph.tsx
@@ -38,7 +38,18 @@ const PhotographDetail = () => {
 
       <div>
         <h1 className="text-lg text-black/85">{photograph.name}</h1>
-        // Add link here
+
+        {photograph.full_url && (
+          <a
+            href={photograph.full_url.replace("/square/", "/full/")}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-blue-600 underline hover:text-blue-800 block mt-1"
+          >
+            View Full Image
+          </a>
+        )}
+
         <div
           dangerouslySetInnerHTML={{
             __html:

--- a/app/routes/collections.photographs.$photograph.tsx
+++ b/app/routes/collections.photographs.$photograph.tsx
@@ -1,12 +1,13 @@
 import { Link, useLoaderData } from "@remix-run/react";
-import { photosIndexCollection } from "~/config";
-import { fetchBySlug } from "~/data/coredata";
-import IIIFViewer from "~/components/layout/IIIFViewer.client";
-import { ClientOnly } from "remix-utils/client-only";
-import type { LoaderFunctionArgs } from "@remix-run/node";
-import type { ESPhotographItem } from "~/esTypes";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
+import { ClientOnly } from "remix-utils/client-only";
+import IIIFViewer from "~/components/layout/IIIFViewer.client";
+import { photosIndexCollection } from "~/config";
+import { fetchBySlug } from "~/data/coredata";
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import type { ESPhotographItem } from "~/esTypes";
+
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const photograph: ESPhotographItem = await fetchBySlug(
@@ -46,10 +47,10 @@ const PhotographDetail = () => {
             href={photograph.full_url.replace("/square/", "/full/")}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-sm text-blue-600 underline hover:text-blue-800 block mt-1"
+            className="text-sm text-blue-600 underline hover:text-blue-800 block mt-1 w-fit flex items-center"
           >
             View Full Image
-            <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-sm" />
+            <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-sm ms-2" />
           </a>
         )}
 

--- a/app/routes/collections.photographs.$photograph.tsx
+++ b/app/routes/collections.photographs.$photograph.tsx
@@ -38,11 +38,12 @@ const PhotographDetail = () => {
 
       <div>
         <h1 className="text-lg text-black/85">{photograph.name}</h1>
+        // Add link here
         <div
           dangerouslySetInnerHTML={{
             __html:
               photograph.description ??
-              "Velit quis veniam commodo fugiat proident officia aute exercitation dolor duis amet non reprehenderit. Elit dolore ut Lorem dolore adipisicing nostrud cillum irure esse esse ipsum incididunt. In sunt laborum do aliqua magna veniam irure enim id officia. Est non qui commodo esse.",
+              "",
           }}
         />
       </div>

--- a/app/routes/collections.photographs.$photograph.tsx
+++ b/app/routes/collections.photographs.$photograph.tsx
@@ -5,6 +5,8 @@ import IIIFViewer from "~/components/layout/IIIFViewer.client";
 import { ClientOnly } from "remix-utils/client-only";
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import type { ESPhotographItem } from "~/esTypes";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const photograph: ESPhotographItem = await fetchBySlug(
@@ -47,6 +49,7 @@ const PhotographDetail = () => {
             className="text-sm text-blue-600 underline hover:text-blue-800 block mt-1"
           >
             View Full Image
+            <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-sm" />
           </a>
         )}
 


### PR DESCRIPTION
Provide a link to the full image on the IIIF server.

Check the file that was changed by the initial commit. There is a comment on line 41 indicating where to insert the link. The photograph object is of type `ESPhotographItem` which is defined in `app/esTypes.ts` and looks like:

~~~ts
export type ESPhotographItem = {
  alt?: string;
  description?: string;
  full_url: string;
  manifest: string;
  name: string;
  places: string[];
  slug: string;
  title?: string;
  thumbnail_rul: string;
  uuid: string;
};
~~~

The `full_url` should look something like https://iiif-cloud.ecdsdev.org/iiif/3/qs9u7recb6ogxogmjqln65slc3z5/full/max/0/default.jpg