### PR TITLE
Feature/collection meta tags

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -19,14 +19,14 @@ import "@fortawesome/fontawesome-svg-core/styles.css";
 // Prevent fontawesome from adding its CSS since we did it manually above:
 import { config } from "@fortawesome/fontawesome-svg-core";
 config.autoAddCss = false; /* eslint-disable import/first */
-import { pageMetadata } from "~/utils/pageMetadata";
+import { placeMetaTags } from "~/utils/placeMetaTags";
 import { MapContext } from "./contexts";
 import { useState } from "react";
 import type { LinksFunction, MetaFunction } from "@remix-run/node";
 import type { Map as TMap } from "maplibre-gl";
 
 export const meta: MetaFunction = () => {
-  return pageMetadata();
+  return placeMetaTags();
 };
 
 export const links: LinksFunction = () => [

--- a/app/routes/about.project.tsx
+++ b/app/routes/about.project.tsx
@@ -1,6 +1,6 @@
 import { dataHosts } from "~/config";
 import { useLoaderData } from "@remix-run/react";
-import { pageMetaDefaults } from "~/utils/pageMetadata";
+import { placeMetaDefaults } from "~/utils/placeMetaTags";
 import wpCssUrl from "~/styles/about.css?url";
 import type { TWordPressData } from "~/types";
 import type { MetaFunction } from "@remix-run/react";
@@ -23,7 +23,7 @@ export const links: LinksFunction = () => {
 export const meta: MetaFunction = () => {
   return [
     {
-      ...pageMetaDefaults,
+      ...placeMetaDefaults,
       title: "About the Project: Georgia Coast Atlas",
     },
   ];

--- a/app/routes/collections.maps._index.tsx
+++ b/app/routes/collections.maps._index.tsx
@@ -8,6 +8,7 @@ import { renderToString } from "react-dom/server";
 import { useLoaderData } from "@remix-run/react";
 import { mapIndexCollection, searchRouter } from "~/config";
 import { mapCollection } from "~/utils/elasticsearchAdapter";
+import { collectionMetadata } from "~/utils/collectionMetaTags";
 import PlaceFacets from "~/components/collections/PlaceFacets";
 import CollectionList from "~/components/collections/CollectionList";
 import Thumbnails from "~/components/collections/Thumbnails";
@@ -74,3 +75,11 @@ const MapCollectionPage = () => {
 };
 
 export default MapCollectionPage;
+
+export const meta = () =>
+  collectionMetadata({
+    title: "Maps Collection",
+    description: "TODO: Add descriptive text about the maps collection here.",
+    image: "TODO: Add a valid og:image URL for the maps collection here.",
+    slug: "maps",
+  });

--- a/app/routes/collections.panos._index.tsx
+++ b/app/routes/collections.panos._index.tsx
@@ -9,6 +9,7 @@ import type { LoaderFunction } from "@remix-run/node";
 import { panosIndexCollection, searchRouter } from "~/config";
 import { panoCollection } from "~/utils/elasticsearchAdapter";
 import { useLoaderData } from "@remix-run/react";
+import { collectionMetadata } from "~/utils/collectionMetaTags";
 import PlaceFacets from "~/components/collections/PlaceFacets";
 import CollectionList from "~/components/collections/CollectionList";
 import Thumbnails from "~/components/collections/Thumbnails";
@@ -59,3 +60,11 @@ const PanoCollectionIndex = () => {
 };
 
 export default PanoCollectionIndex;
+
+export const meta = () =>
+  collectionMetadata({
+    title: "Panos Collection",
+    description: "TODO: Add descriptive text about the panos collection here.",
+    image: "TODO: Add a valid og:image URL for the panos collection here.",
+    slug: "panos",
+  });

--- a/app/routes/collections.photographs._index.tsx
+++ b/app/routes/collections.photographs._index.tsx
@@ -8,6 +8,7 @@ import { renderToString } from "react-dom/server";
 import { useLoaderData } from "@remix-run/react";
 import { photosIndexCollection, searchRouter } from "~/config";
 import { photoCollection } from "~/utils/elasticsearchAdapter";
+import { collectionMetadata } from "~/utils/collectionMetaTags";
 import PlaceFacets from "~/components/collections/PlaceFacets";
 import CollectionList from "~/components/collections/CollectionList";
 import Thumbnails from "~/components/collections/Thumbnails";
@@ -59,3 +60,11 @@ const PhotographCollectionIndex = () => {
 };
 
 export default PhotographCollectionIndex;
+
+export const meta = () =>
+  collectionMetadata({
+    title: "Photograph Collection",
+    description: "TODO: Add descriptive text about the photograph collection here.",
+    image: "TODO: Add a valid og:image URL for the photograph collection here.",
+    slug: "photographs",
+  });

--- a/app/routes/collections.videos._index.tsx
+++ b/app/routes/collections.videos._index.tsx
@@ -8,6 +8,7 @@ import { renderToString } from "react-dom/server";
 import { useLoaderData } from "@remix-run/react";
 import { searchRouter, videosIndexCollection } from "~/config";
 import { videoCollection } from "~/utils/elasticsearchAdapter";
+import { collectionMetadata } from "~/utils/collectionMetaTags";
 import CollectionList from "~/components/collections/CollectionList";
 import PlaceFacets from "~/components/collections/PlaceFacets";
 import Thumbnails from "~/components/collections/Thumbnails";
@@ -66,3 +67,11 @@ const VideoCollectionIndex = () => {
 };
 
 export default VideoCollectionIndex;
+
+export const meta = () =>
+  collectionMetadata({
+    title: "Videos Collection",
+    description: "TODO: Add descriptive text about the videos collection here.",
+    image: "TODO: Add a valid og:image URL for the videos collection here.",
+    slug: "videos",
+  });

--- a/app/routes/places.$id.tsx
+++ b/app/routes/places.$id.tsx
@@ -10,7 +10,7 @@ import { fetchBySlug } from "~/data/coredata";
 import Heading from "~/components/layout/Heading";
 import FeaturedMedium from "~/components/FeaturedMedium";
 import { dataHosts, indexCollection } from "~/config";
-import { pageMetadata } from "~/utils/pageMetadata";
+import { placeMetaTags } from "~/utils/placeMetaTags";
 import RelatedPlaces from "~/components/relatedRecords/RelatedPlaces";
 import RelatedMapLayers from "~/components/relatedRecords/RelatedMapLayers";
 import RelatedTopoQuads from "~/components/relatedRecords/RelatedTopoQuads";
@@ -23,7 +23,7 @@ import type { TWordPressData } from "~/types";
 import type { LngLatBounds } from "maplibre-gl";
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
-  return pageMetadata(data?.place as ESPlace);
+  return placeMetaTags(data?.place as ESPlace);
 };
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
@@ -62,12 +62,12 @@ const PlacePage = () => {
   const [noTrackMouse, setNoTrackMouse] = useState<boolean>(false);
   const [backTo, setBackTo] = useState<
     | {
-        slug: string;
-        title: string;
-        bounds?: LngLatBounds;
-        previous: string;
-        search?: string;
-      }
+      slug: string;
+      title: string;
+      bounds?: LngLatBounds;
+      previous: string;
+      search?: string;
+    }
     | undefined
   >(undefined);
   const topRef = useRef<HTMLDivElement>(null);
@@ -125,7 +125,7 @@ const PlacePage = () => {
         />
         <div className="px-4">
           {place.types.includes("Barrier Island") ||
-          place.types.includes("County") ? (
+            place.types.includes("County") ? (
             <RelatedPlaces />
           ) : (
             <PlaceMap />

--- a/app/routes/places.search.tsx
+++ b/app/routes/places.search.tsx
@@ -16,7 +16,7 @@ import SearchForm from "~/components/search/SearchForm";
 import { indexCollection } from "~/config";
 import { SearchContext } from "~/contexts";
 import SearchResult from "~/components/search/SearchResult";
-import { pageMetaDefaults } from "~/utils/pageMetadata";
+import { placeMetaDefaults } from "~/utils/placeMetaTags";
 // import SearchModal from "~/components/search/SearchModal";
 import type { LoaderFunction } from "@remix-run/node";
 import type { Navigation, Location, MetaFunction } from "@remix-run/react";
@@ -54,7 +54,7 @@ export const loader: LoaderFunction = async ({ request }) => {
 export const meta: MetaFunction = () => {
   return [
     {
-      ...pageMetaDefaults,
+      ...placeMetaDefaults,
       title: "Search: Georgia Coast Atlas",
     },
   ];

--- a/app/utils/collectionMetaTags.ts
+++ b/app/utils/collectionMetaTags.ts
@@ -1,0 +1,42 @@
+type CollectionMetaArgs = {
+    title: string;
+    description?: string;
+    image: string;
+    slug: string;
+};
+
+export const collectionMetadata = ({
+    title,
+    description,
+    image,
+    slug,
+}: CollectionMetaArgs) => {
+    const siteName = "Georgia Coast Atlas";
+    const siteUrl = "https://georgiacoastatlas.org";
+
+    const fallbackDescription = `Explore content from the ${title} of the Georgia Coast Atlas.`;
+
+    return [
+        { title: `${title} | ${siteName}` },
+        {
+            name: "description",
+            content: description ?? fallbackDescription,
+        },
+        {
+            property: "og:title",
+            content: `${title} | ${siteName}`,
+        },
+        {
+            property: "og:description",
+            content: description ?? fallbackDescription,
+        },
+        { property: "og:image", content: image },
+        { property: "og:image:width", content: "1200" },
+        { property: "og:image:height", content: "630" },
+        {
+            property: "og:url",
+            content: `${siteUrl}/collections/${slug}`,
+        },
+        { name: "twitter:card", content: "summary_large_image" },
+    ];
+};

--- a/app/utils/placeMetaTags.ts
+++ b/app/utils/placeMetaTags.ts
@@ -65,7 +65,7 @@ const mentions = (place: ESPlace) => {
   }
 };
 
-export const pageMetaDefaults = [
+export const placeMetaDefaults = [
   {
     title: "Georgia Coast Atlas",
   },
@@ -102,7 +102,7 @@ export const pageMetaDefaults = [
   },
 ];
 
-export const pageMetadata = (place: ESPlace | undefined = undefined) => {
+export const placeMetaTags = (place: ESPlace | undefined = undefined) => {
   if (place) {
     return [
       {
@@ -192,5 +192,5 @@ export const pageMetadata = (place: ESPlace | undefined = undefined) => {
     ];
   }
 
-  return pageMetaDefaults;
+  return placeMetaDefaults;
 };


### PR DESCRIPTION
Added meta tags to the collection index routes using a new function `collectionMetadata` from `app/utils/collectionMetaTags.ts`.

- Renamed `pageMetadata.ts` to `placeMetaTags.ts` for clarity
- Created `collectionMetaTags.ts` for handling meta tags on collection pages
- Implemented `collectionMetadata()` function with fallback support for missing descriptions
- Applied `meta` export to the photograph collection index route using placeholders

Fixes #32 